### PR TITLE
refactor: update PHP and Laravel version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This package provides utilities for building a restful API for Laravel projects.
 
-This package requires PHP >= 8.0, Laravel ^8.0, ^9.0, ^10.0 and ^11.0.
+This package requires PHP >= 8.2, and supports Laravel 9~12.
 
 ## Setup
 

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         }
     ],
     "require": {
-        "laravel/framework": "^8.0|^9.0|^10.0|^11.0",
-        "php": ">=8.0"
+        "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
+        "php": ">=8.2"
     },
     "extra": {
         "laravel": {
@@ -33,7 +33,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^1.8"
+        "phpunit/phpunit": "^11.5",
+        "phpstan/phpstan": "^2.1"
     }
 }


### PR DESCRIPTION
This commit updates the supported PHP and Laravel versions for the package.

- PHP requirement has been upgraded from `^8.0` to `^8.2`.
- Laravel support now includes `^12.0` in addition to `^9.0`, `^10.0`, and `^11.0`. Meanwhile, Laravel `^8.0` support has been dropped.
- Development dependencies `phpunit/phpunit` and `phpstan/phpstan` have been updated to their latest compatible versions.
