### PR TITLE
ci(phpunit): upgrade to php-actions/phpunit@v4

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,11 +17,13 @@ jobs:
         uses: php-actions/composer@v6
 
       - name: PHPUnit Tests
-        uses: php-actions/phpunit@master
+        uses: php-actions/phpunit@v4
+        env:
+          XDEBUG_MODE: coverage
         with:
-          bootstrap: vendor/autoload.php
+          php_extensions: xdebug
           configuration: phpunit.xml
-          args: --coverage-text
+          coverage_text: true
 
       - name: PHP Code Sniffer
         uses: php-actions/phpcs@v1


### PR DESCRIPTION
This PR solves the [failed CI job](https://github.com/nycu-csit/laravel-restful-utils/actions/runs/15325012691/job/43117212957), and upgrades `php-actions/phpunit` to `v4`.