### PR TITLE
Adapt to PHPUnit 11 and PHPStan 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vendor/
 
 # PHPUnit
 .phpunit.result.cache
+.phpunit.cache/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,8 @@ parameters:
 
     # The level 9 is the highest level
     level: 5
+    ignoreErrors:
+        -
+            identifier: trait.unused
+        -
+            identifier: varTag.nativeType

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         colors="true"
->
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         shortenArraysForExportThreshold="10"
+         requireCoverageMetadata="false"
+         beStrictAboutCoverageMetadata="false"
+         beStrictAboutOutputDuringTests="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         failOnPhpunitDeprecation="true"
+         failOnRisky="false"
+         failOnWarning="false">
     <testsuites>
-        <testsuite name="Unit">
-            <directory>./tests</directory>
+        <testsuite name="default">
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+
+    <source ignoreIndirectDeprecations="true" restrictNotices="true" restrictWarnings="true">
         <include>
-            <directory suffix=".php">./src</directory>
+            <directory>src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -28,6 +28,7 @@ class Handler extends ExceptionHandler
     protected function shouldReturnJson($request, Throwable $e)
     {
         $route = $request->route();
+        // @phpstan-ignore instanceof.alwaysTrue
         $middlewareGroup = $route instanceof Route ? $route->gatherMiddleware() : [];
 
         return parent::shouldReturnJson($request, $e) || in_array('api', $middlewareGroup);

--- a/src/Exceptions/HttpApiException.php
+++ b/src/Exceptions/HttpApiException.php
@@ -55,6 +55,7 @@ class HttpApiException extends RuntimeException
         } elseif (
             is_object($code) &&
             is_a($code, '\BackedEnum') &&
+            // @phpstan-ignore function.alreadyNarrowedType
             property_exists($code, 'value') &&
             is_string($code->value)
         ) {

--- a/tests/Exceptions/HttpApiExceptionTest.php
+++ b/tests/Exceptions/HttpApiExceptionTest.php
@@ -4,6 +4,7 @@ namespace Tests\Exceptions;
 
 use InvalidArgumentException;
 use NycuCsit\LaravelRestfulUtils\Exceptions\HttpApiException;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class HttpApiExceptionTest extends TestCase
@@ -18,6 +19,7 @@ class HttpApiExceptionTest extends TestCase
     /**
      * @requires PHP 8.1
      */
+    #[Test]
     public function test_constructor_invalid_int_backed_enum_code()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -37,6 +39,7 @@ class HttpApiExceptionTest extends TestCase
     /**
      * @requires PHP 8.1
      */
+    #[Test]
     public function test_constructor_enum_code()
     {
         $e = new HttpApiException(200, \Tests\TestEnum::Test1);


### PR DESCRIPTION
In #3 only dependencies were upgraded, but the required configuration changes for PHPUnit and PHPStan were missing. This PR fixes [failed CI job](https://github.com/nycu-csit/laravel-restful-utils/actions/runs/15326209104/job/43121265158), and makes proper adjustments to PHPStan configuration and solves type-hinting issues.